### PR TITLE
Recognize dash as a valid relationship separator

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -26,7 +26,7 @@ class GamesController < ApplicationController
   attr_accessor :game
 
   def include_params
-    params[:include]&.split(",")
+    params[:include]&.split(",")&.map { |relationship| relationship.tr("-", "_") }
   end
 
   def game_params

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -48,5 +48,30 @@ RSpec.describe "Games" do
         )
       end
     end
+
+    context "with included relationships using dashes instead of underscores" do
+      it "responds with included relationships" do
+        get "/games/#{game_id}?include=houses,garrison-tokens,influence-tokens"
+        parsed_response = JSON.parse(response.body)
+
+        expect(parsed_response["included"]).to contain_exactly(
+          include("type" => "house"),
+          include("type" => "house"),
+          include("type" => "house"),
+          include("type" => "garrison-token"),
+          include("type" => "garrison-token"),
+          include("type" => "garrison-token"),
+          include("type" => "influence-token"),
+          include("type" => "influence-token"),
+          include("type" => "influence-token"),
+          include("type" => "influence-token"),
+          include("type" => "influence-token"),
+          include("type" => "influence-token"),
+          include("type" => "influence-token"),
+          include("type" => "influence-token"),
+          include("type" => "influence-token")
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
When requesting for a given `Game`, the response body **does not** include the attributes of `Game`'s relationships. To include them, you have to pass the desired relationships inside the `include` query string.

Previously, the API only recognized relationships that used underscores as a separator, e.g.: `GET /games/1?include=houses,wildling_cards`.

This PR allows for dashes as a separator, e.g.: `GET /games/1?include=houses,wildling-cards`.

Since the API response uses dashes as separator, it makes sense to also accept it in the request query string. This also means you can directly inject the relationships fetched from the response body into the next request path, without having to transform them.